### PR TITLE
Decouple PulseAudio support from ALSA.

### DIFF
--- a/lib/init.scm
+++ b/lib/init.scm
@@ -77,6 +77,8 @@
 (cond
  ((member 'nas *modules*)
   (Parameter.def 'Audio_Method 'netaudio))
+ ((member 'pulse *modules*)
+  (Parameter.def 'Audio_Method 'pulseaudio))
  ((member 'esd *modules*)
   (Parameter.def 'Audio_Method 'esdaudio))
  ((member 'sun16audio *modules*)

--- a/src/arch/festival/festival.cc
+++ b/src/arch/festival/festival.cc
@@ -342,6 +342,8 @@ void festival_lisp_vars(void)
     siod_set_lval("*module-descriptions*",NIL);
     if (nas_supported)
 	proclaim_module("nas");
+    if (pulse_supported)
+	proclaim_module("pulse");
     if (esd_supported)
 	proclaim_module("esd");
     if (sun16_supported)


### PR DESCRIPTION
Depends on https://github.com/festvox/speech_tools/pull/33