### PR TITLE
Feature: Improve voice language listing

### DIFF
--- a/lib/languages/language_american_english.scm
+++ b/lib/languages/language_american_english.scm
@@ -1,0 +1,74 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                                                                       ;;
+;;;                Centre for Speech Technology Research                  ;;
+;;;                     University of Edinburgh, UK                       ;;
+;;;                         Copyright (c) 2002                            ;;
+;;;                        All Rights Reserved.                           ;;
+;;;                                                                       ;;
+;;;  Permission is hereby granted, free of charge, to use and distribute  ;;
+;;;  this software and its documentation without restriction, including   ;;
+;;;  without limitation the rights to use, copy, modify, merge, publish,  ;;
+;;;  distribute, sublicense, and/or sell copies of this work, and to      ;;
+;;;  permit persons to whom this work is furnished to do so, subject to   ;;
+;;;  the following conditions:                                            ;;
+;;;   1. The code must retain the above copyright notice, this list of    ;;
+;;;      conditions and the following disclaimer.                         ;;
+;;;   2. Any modifications must be clearly marked as such.                ;;
+;;;   3. Original authors' names are not deleted.                         ;;
+;;;   4. The authors' names are not used to endorse or promote products   ;;
+;;;      derived from this software without specific prior written        ;;
+;;;      permission.                                                      ;;
+;;;                                                                       ;;
+;;;  THE UNIVERSITY OF EDINBURGH AND THE CONTRIBUTORS TO THIS WORK        ;;
+;;;  DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING      ;;
+;;;  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT   ;;
+;;;  SHALL THE UNIVERSITY OF EDINBURGH NOR THE CONTRIBUTORS BE LIABLE     ;;
+;;;  FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES    ;;
+;;;  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN   ;;
+;;;  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,          ;;
+;;;  ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF       ;;
+;;;  THIS SOFTWARE.                                                       ;;
+;;;                                                                       ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                         Author: 
+;;;                         Date:   
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; American English language description
+;;
+;;
+
+(define (language_american_english)
+"(language_american_english)
+Set up language parameters for American English."
+
+  (let ( (mydefault_voices (language.get_voices 'american_english))
+       )
+  (if (not (null (cadr (assoc 'male mydefault_voices ))))
+    (set! male1 (lambda () (voice.select (nth 0 (cadr (assoc 'male mydefault_voices))))))
+    (set! male1 nil)
+  )
+  (if (not (null (cadr (assoc 'female mydefault_voices ))))
+    (set! female1 (lambda () (voice.select (nth 0 (cadr (assoc 'female mydefault_voices))))))
+    (set! female1 nil)
+  )
+  (if (null male1)
+     (if (null female1)
+        (format t "Not an american English voice installed")
+        (female1)
+     )
+     (male1)
+  )
+  (Param.set 'Language 'americanenglish)
+current-voice
+  )
+)
+
+(proclaim_language
+ 'american_english
+ '((language english)
+   (dialect american)
+   (default_male (list ked_diphone))
+   (default_female (list kal_diphone))
+   (aliases (list americanenglish))
+  ))

--- a/lib/languages/language_british_english.scm
+++ b/lib/languages/language_british_english.scm
@@ -1,0 +1,94 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                                                                       ;;
+;;;                Centre for Speech Technology Research                  ;;
+;;;                     University of Edinburgh, UK                       ;;
+;;;                         Copyright (c) 2002                            ;;
+;;;                        All Rights Reserved.                           ;;
+;;;                                                                       ;;
+;;;  Permission is hereby granted, free of charge, to use and distribute  ;;
+;;;  this software and its documentation without restriction, including   ;;
+;;;  without limitation the rights to use, copy, modify, merge, publish,  ;;
+;;;  distribute, sublicense, and/or sell copies of this work, and to      ;;
+;;;  permit persons to whom this work is furnished to do so, subject to   ;;
+;;;  the following conditions:                                            ;;
+;;;   1. The code must retain the above copyright notice, this list of    ;;
+;;;      conditions and the following disclaimer.                         ;;
+;;;   2. Any modifications must be clearly marked as such.                ;;
+;;;   3. Original authors' names are not deleted.                         ;;
+;;;   4. The authors' names are not used to endorse or promote products   ;;
+;;;      derived from this software without specific prior written        ;;
+;;;      permission.                                                      ;;
+;;;                                                                       ;;
+;;;  THE UNIVERSITY OF EDINBURGH AND THE CONTRIBUTORS TO THIS WORK        ;;
+;;;  DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING      ;;
+;;;  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT   ;;
+;;;  SHALL THE UNIVERSITY OF EDINBURGH NOR THE CONTRIBUTORS BE LIABLE     ;;
+;;;  FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES    ;;
+;;;  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN   ;;
+;;;  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,          ;;
+;;;  ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF       ;;
+;;;  THIS SOFTWARE.                                                       ;;
+;;;                                                                       ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                         Author: 
+;;;                         Date:  
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; British English language description
+;;
+;;
+
+(define (language_british_english)
+"(language_british_english)
+Set up language parameters for British English."
+
+  (let ( (mydefault_voices (language.get_voices 'british_english))
+         (mymalevoices nil)
+         (myfemalevoices nil)
+       )
+  (set! mymalevoices (cadr (assoc 'male mydefault_voices)))
+  (if (> (length mymalevoices) 0)
+    (set! male1 (lambda () (voice.select (nth 0 mymalevoices))))
+    (set! male1 nil)
+  )
+  (if (> (length mymalevoices) 1)
+    (set! male2 (lambda () (voice.select (nth 1 mymalevoices))))
+    (set! male2 nil)
+  )
+  (if (> (length mymalevoices) 2)
+    (set! male3 (lambda () (voice.select (nth 2 mymalevoices))))
+    (set! male3 nil)
+  )
+  (if (> (length mymalevoices) 3)
+    (set! male4 (lambda () (voice.select (nth 3 mymalevoices))))
+    (set! male4 nil)
+  )
+
+
+  (set! myfemalevoices (cadr (assoc 'female mydefault_voices)))
+  (if (> (length myfemalevoices) 0)
+    (set! female1 (lambda () (voice.select (nth 0 myfemalevoices))))
+    (set! female1 nil)
+  )
+  
+  (if (null male1)
+     (if (null female1)
+        (format t "Not a british English voice installed")
+        (female1)
+     )
+     (male1)
+  )
+  (Param.set 'Language 'britishenglish)
+nil
+  )
+)
+
+(proclaim_language
+ 'british_english
+ '((language english)
+   (dialect british)
+   (default_male (list rab_diphone don_diphone gsw_diphone gsw_450))
+   (default_female nil)
+   (aliases (list britishenglish))
+  ))
+

--- a/lib/languages/language_castillian_spanish.scm
+++ b/lib/languages/language_castillian_spanish.scm
@@ -1,0 +1,80 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                                                                       ;;
+;;;                Centre for Speech Technology Research                  ;;
+;;;                     University of Edinburgh, UK                       ;;
+;;;                         Copyright (c) 2002                            ;;
+;;;                        All Rights Reserved.                           ;;
+;;;                                                                       ;;
+;;;  Permission is hereby granted, free of charge, to use and distribute  ;;
+;;;  this software and its documentation without restriction, including   ;;
+;;;  without limitation the rights to use, copy, modify, merge, publish,  ;;
+;;;  distribute, sublicense, and/or sell copies of this work, and to      ;;
+;;;  permit persons to whom this work is furnished to do so, subject to   ;;
+;;;  the following conditions:                                            ;;
+;;;   1. The code must retain the above copyright notice, this list of    ;;
+;;;      conditions and the following disclaimer.                         ;;
+;;;   2. Any modifications must be clearly marked as such.                ;;
+;;;   3. Original authors' names are not deleted.                         ;;
+;;;   4. The authors' names are not used to endorse or promote products   ;;
+;;;      derived from this software without specific prior written        ;;
+;;;      permission.                                                      ;;
+;;;                                                                       ;;
+;;;  THE UNIVERSITY OF EDINBURGH AND THE CONTRIBUTORS TO THIS WORK        ;;
+;;;  DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING      ;;
+;;;  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT   ;;
+;;;  SHALL THE UNIVERSITY OF EDINBURGH NOR THE CONTRIBUTORS BE LIABLE     ;;
+;;;  FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES    ;;
+;;;  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN   ;;
+;;;  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,          ;;
+;;;  ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF       ;;
+;;;  THIS SOFTWARE.                                                       ;;
+;;;                                                                       ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                         Author: 
+;;;                         Date:   
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Castillian Spanish language description
+;;
+;;
+
+(define (language_castillian_spanish)
+"(language_castillian_spanish)
+Set up language parameters for Castillian Spanish."
+
+  (let ( (mydefault_voices (language.get_voices 'spanish))
+         (mymalevoices nil)
+         (myfemalevoices nil)
+       )
+  (set! mymalevoices (cadr (assoc 'male mydefault_voices)))
+  (if (> (length mymalevoices) 0)
+    (set! male1 (lambda () (voice.select (nth 0 mymalevoices))))
+    (set! male1 nil)
+  )
+
+  (set! myfemalevoices (cadr (assoc 'female mydefault_voices)))
+  (if (> (length myfemalevoices) 0)
+    (set! female1 (lambda () (voice.select (nth 0 myfemalevoices))))
+    (set! female1 nil)
+  )
+
+  (if (null male1)
+     (if (null female1)
+        (format t "Not a Spanish voice installed")
+        (female1)
+     )
+     (male1)
+  )
+  (Param.set 'Language 'spanish)
+nil
+  )
+)
+
+(proclaim_language
+ 'castillian_spanish
+ '((language spanish)
+   (default_male (list el_diphone))
+   (default_female nil)
+   (aliases (list spanish castellano))
+  ))
+

--- a/lib/languages/language_english.scm
+++ b/lib/languages/language_english.scm
@@ -1,0 +1,78 @@
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                                                                       ;;
+;;;                Centre for Speech Technology Research                  ;;
+;;;                     University of Edinburgh, UK                       ;;
+;;;                         Copyright (c) 2002                            ;;
+;;;                        All Rights Reserved.                           ;;
+;;;                                                                       ;;
+;;;  Permission is hereby granted, free of charge, to use and distribute  ;;
+;;;  this software and its documentation without restriction, including   ;;
+;;;  without limitation the rights to use, copy, modify, merge, publish,  ;;
+;;;  distribute, sublicense, and/or sell copies of this work, and to      ;;
+;;;  permit persons to whom this work is furnished to do so, subject to   ;;
+;;;  the following conditions:                                            ;;
+;;;   1. The code must retain the above copyright notice, this list of    ;;
+;;;      conditions and the following disclaimer.                         ;;
+;;;   2. Any modifications must be clearly marked as such.                ;;
+;;;   3. Original authors' names are not deleted.                         ;;
+;;;   4. The authors' names are not used to endorse or promote products   ;;
+;;;      derived from this software without specific prior written        ;;
+;;;      permission.                                                      ;;
+;;;                                                                       ;;
+;;;  THE UNIVERSITY OF EDINBURGH AND THE CONTRIBUTORS TO THIS WORK        ;;
+;;;  DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING      ;;
+;;;  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT   ;;
+;;;  SHALL THE UNIVERSITY OF EDINBURGH NOR THE CONTRIBUTORS BE LIABLE     ;;
+;;;  FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES    ;;
+;;;  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN   ;;
+;;;  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,          ;;
+;;;  ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF       ;;
+;;;  THIS SOFTWARE.                                                       ;;
+;;;                                                                       ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                         Author: 
+;;;                         Date:   
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; American English language description
+;;
+;;
+
+(define (language_english)
+"(language_english)
+Set up language parameters for English."
+
+  (let ( (mydefault_voices (language.get_voices 'english)))
+
+  (if (cadr (assoc 'male mydefault_voices ))
+    (set! male1 (lambda () (voice.select (car (cadr (assoc 'male mydefault_voices))))))
+    (set! male1 nil)
+  )
+
+  (if (cadr (assoc 'female mydefault_voices ))
+    (set! female1 (lambda () (voice.select (car (cadr (assoc 'female mydefault_voices))))))
+    (set! female1 nil)
+  )
+  
+  (if (null male1)
+     (if (null female1)
+        (format t "Not an English voice installed")
+        (female1)
+     )
+     (male1)
+  )
+  (if (equal? 'american (cdr (assoc 'dialect (cdr (assoc current-voice Voice_descriptions)))))
+     (Param.set 'Language 'americanenglish)
+     (Param.set 'Language 'britishenglish)
+  )
+ )
+current-voice
+)
+
+(proclaim_language
+ 'english
+ '((language english)
+   (default_male (list rab_diphone don_diphone))
+   (default_female nil)
+   (aliases nil)
+  ))

--- a/lib/languages/language_scots_gaelic.scm
+++ b/lib/languages/language_scots_gaelic.scm
@@ -1,0 +1,55 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                                                                       ;;
+;;;                Centre for Speech Technology Research                  ;;
+;;;                     University of Edinburgh, UK                       ;;
+;;;                         Copyright (c) 2002                            ;;
+;;;                        All Rights Reserved.                           ;;
+;;;                                                                       ;;
+;;;  Permission is hereby granted, free of charge, to use and distribute  ;;
+;;;  this software and its documentation without restriction, including   ;;
+;;;  without limitation the rights to use, copy, modify, merge, publish,  ;;
+;;;  distribute, sublicense, and/or sell copies of this work, and to      ;;
+;;;  permit persons to whom this work is furnished to do so, subject to   ;;
+;;;  the following conditions:                                            ;;
+;;;   1. The code must retain the above copyright notice, this list of    ;;
+;;;      conditions and the following disclaimer.                         ;;
+;;;   2. Any modifications must be clearly marked as such.                ;;
+;;;   3. Original authors' names are not deleted.                         ;;
+;;;   4. The authors' names are not used to endorse or promote products   ;;
+;;;      derived from this software without specific prior written        ;;
+;;;      permission.                                                      ;;
+;;;                                                                       ;;
+;;;  THE UNIVERSITY OF EDINBURGH AND THE CONTRIBUTORS TO THIS WORK        ;;
+;;;  DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING      ;;
+;;;  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT   ;;
+;;;  SHALL THE UNIVERSITY OF EDINBURGH NOR THE CONTRIBUTORS BE LIABLE     ;;
+;;;  FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES    ;;
+;;;  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN   ;;
+;;;  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,          ;;
+;;;  ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF       ;;
+;;;  THIS SOFTWARE.                                                       ;;
+;;;                                                                       ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                         Author: 
+;;;                         Date:   
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Scots Gaelic language description
+;;
+;;
+
+(define (language_scots_gaelic)
+"(language_scots_gaelic)
+Set up language parameters for Scots Gaelic."
+  (error "Scots Gaelic not yet supported.")
+
+  (Param.set 'Language 'scotsgaelic)
+)
+
+(proclaim_language
+ 'scots_gaelic
+ '((language scotsgaelic)
+   (default_male nil)
+   (default_female nil)
+   (aliases (list scotsgaelic))
+  ))

--- a/lib/languages/language_welsh.scm
+++ b/lib/languages/language_welsh.scm
@@ -1,0 +1,80 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                                                                       ;;
+;;;                Centre for Speech Technology Research                  ;;
+;;;                     University of Edinburgh, UK                       ;;
+;;;                         Copyright (c) 2002                            ;;
+;;;                        All Rights Reserved.                           ;;
+;;;                                                                       ;;
+;;;  Permission is hereby granted, free of charge, to use and distribute  ;;
+;;;  this software and its documentation without restriction, including   ;;
+;;;  without limitation the rights to use, copy, modify, merge, publish,  ;;
+;;;  distribute, sublicense, and/or sell copies of this work, and to      ;;
+;;;  permit persons to whom this work is furnished to do so, subject to   ;;
+;;;  the following conditions:                                            ;;
+;;;   1. The code must retain the above copyright notice, this list of    ;;
+;;;      conditions and the following disclaimer.                         ;;
+;;;   2. Any modifications must be clearly marked as such.                ;;
+;;;   3. Original authors' names are not deleted.                         ;;
+;;;   4. The authors' names are not used to endorse or promote products   ;;
+;;;      derived from this software without specific prior written        ;;
+;;;      permission.                                                      ;;
+;;;                                                                       ;;
+;;;  THE UNIVERSITY OF EDINBURGH AND THE CONTRIBUTORS TO THIS WORK        ;;
+;;;  DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING      ;;
+;;;  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT   ;;
+;;;  SHALL THE UNIVERSITY OF EDINBURGH NOR THE CONTRIBUTORS BE LIABLE     ;;
+;;;  FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES    ;;
+;;;  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN   ;;
+;;;  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,          ;;
+;;;  ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF       ;;
+;;;  THIS SOFTWARE.                                                       ;;
+;;;                                                                       ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                         Author: 
+;;;                         Date:   
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Welsh language description
+;;
+;;
+
+(define (language_welsh)
+"(language_welsh)
+Set up language parameters for Welsh."
+
+  (let ( (mydefault_voices (language.get_voices 'welsh))
+         (mymalevoices nil)
+         (myfemalevoices nil)
+       )
+  (set! mymalevoices (cadr (assoc 'male mydefault_voices)))
+  (if (> (length mymalevoices) 0)
+    (set! male1 (lambda () (voice.select (nth 0 mymalevoices))))
+    (set! male1 nil)
+  )
+
+  (set! myfemalevoices (cadr (assoc 'female mydefault_voices)))
+  (if (> (length myfemalevoices) 0)
+    (set! female1 (lambda () (voice.select (nth 0 myfemalevoices))))
+    (set! female1 nil)
+  )
+
+  (if (null male1)
+     (if (null female1)
+        (format t "Not a Welsh voice installed")
+        (female1)
+     )
+     (male1)
+  )
+  (Param.set 'Language 'welsh)
+current-voice
+  )
+)
+
+(proclaim_language
+ 'welsh
+ '((language welsh)
+   (default_male (list welsh_hl))
+   (default_female nil)
+   (aliases nil)
+  ))
+

--- a/lib/voices.scm
+++ b/lib/voices.scm
@@ -345,7 +345,9 @@ in the proclaim_voice description fields."
        (while voices
 	 (set! voicedir (car voices))
 	 (set! voice (path-basename voicedir))
-	 (if (string-matches voicedir ".*\\..*")
+	 (if (or (string-matches voicedir ".*\\..*") 
+                 (not (probe_file (path-append dir language voicedir "festvox" (string-append voicedir ".scm"))))
+             );; if directory is \.. or voice description doesn't exist, then do nothing. Else, load voice
 	     nil
 	     (begin
 	       ;; load the voice definition file, but don't evaluate it!
@@ -355,7 +357,12 @@ in the proclaim_voice description fields."
 	       (mapcar
 		(lambda (line)
 		  (if (string-matches (car line) "proclaim_voice")
-		      (voice-location-multisyn (intern (cadr (cadr line)))  voicedir (path-append dir language voicedir) "registerd multisyn voice")))
+                    (begin
+		      (voice-location-multisyn (intern (cadr (cadr line)))  voicedir (path-append dir language voicedir) "registerd multisyn voice")
+                      (eval line)
+                    )
+                  )
+                )
 		voice-def-file)
 	     ))
 	 (set! voices (cdr voices)))

--- a/lib/voices.scm
+++ b/lib/voices.scm
@@ -144,12 +144,19 @@ to be used."
 
    ;; The follow are reset to allow existing voices to continue
    ;; to work, new voices should be setting these explicitly
+   (Param.set 'Text_Method 'Text_int)
    (Parameter.set 'Token_Method 'Token_English)
    (Parameter.set 'POS_Method Classic_POS)
    (Parameter.set 'Phrasify_Method Classic_Phrasify)
    (Parameter.set 'Word_Method Classic_Word)
    (Parameter.set 'Pause_Method Classic_Pauses)
    (Parameter.set 'PostLex_Method Classic_PostLex)
+   ;; From pos.scm:
+   (set! pos_p_start_tag "punc")
+   (set! pos_pp_start_tag "nn")
+   (set! pos_supported nil)
+   (set! pos_ngram_name nil)
+   (set! pos_map nil)
 
    (set! diphone_module_hooks nil)
    (set! UniSyn_module_hooks nil)

--- a/lib/voices.scm
+++ b/lib/voices.scm
@@ -388,26 +388,52 @@ A variable whose value is a function name that is called on start up to
 the default voice. [see Site initialization]")
 
 (defvar default-voice-priority-list 
-  '(kal_diphone
-    cmu_us_slt_cg
-    cmu_us_rms_cg
-    cmu_us_bdl_cg
-    cmu_us_jmk_cg
-    cmu_us_awb_cg
-;    cstr_rpx_nina_multisyn       ; restricted license (lexicon)
-;    cstr_rpx_jon_multisyn       ; restricted license (lexicon)
-;    cstr_edi_awb_arctic_multisyn ; restricted license (lexicon)
-;    cstr_us_awb_arctic_multisyn
-    ked_diphone
-    don_diphone
-    rab_diphone
-    en1_mbrola
-    us1_mbrola
-    us2_mbrola
-    us3_mbrola
-    gsw_diphone  ;; not publically distributed
-    el_diphone
+  (reverse (remove-duplicates (reverse 
+  (append 
+    (list
+      ; A default hardcoded list with higher priority
+      'kal_diphone
+      'cmu_us_slt_cg
+      'cmu_us_rms_cg
+      'cmu_us_bdl_cg
+      'cmu_us_jmk_cg
+      'cmu_us_awb_cg
+      'cstr_rpx_nina_multisyn       ; restricted license (lexicon)
+      'cstr_rpx_jon_multisyn       ; restricted license (lexicon)
+      'cstr_edi_awb_arctic_multisyn ; restricted license (lexicon)
+      'cstr_us_awb_arctic_multisyn
+      'nitech_us_slt_arctic_hts
+      'nitech_us_awb_arctic_hts
+      'nitech_us_bdl_arctic_hts
+      'nitech_us_clb_arctic_hts
+      'nitech_us_jmk_arctic_hts
+      'nitech_us_rms_arctic_hts
+      'ked_diphone
+      'don_diphone
+      'rab_diphone
+      'en1_mbrola
+      'us1_mbrola
+      'us2_mbrola
+      'us3_mbrola
+      'gsw_diphone  ;; not publically distributed
+      'el_diphone
+      'ked_diphone
+      'cstr_us_awb_arctic_multisyn
+      'cstr_us_jmk_arctic_multisyn
     )
+    ; Any clustergen voice
+    (voice.find (list (list 'engine 'clustergen)))
+    ; Any hts voice
+    (voice.find (list (list 'engine 'hts)))
+    ; Any multisyn voice
+    (voice.find (list (list 'engine 'multisyn)))
+    ; Any diphone voice
+    (voice.find (list (list 'engine 'diphone)))
+    ; Any clunits voice
+    (voice.find (list (list 'engine 'clunits)))
+    ; Any voice
+    (voice.list)
+  ))))
   "default-voice-priority-list
    List of voice names. The first of them available becomes the default voice.")
 

--- a/lib/voices.scm
+++ b/lib/voices.scm
@@ -139,18 +139,18 @@ This should always be set by the voice definition function (even
 if it does nothing).  This allows voice specific changes to be reset
 when a new voice is selection.  Unfortunately I can't force this
 to be used."
-   (Parameter.set 'Duration_Stretch 1.0)
+   (Param.set 'Duration_Stretch 1.0)
    (set! after_synth_hooks default_after_synth_hooks)
 
    ;; The follow are reset to allow existing voices to continue
    ;; to work, new voices should be setting these explicitly
    (Param.set 'Text_Method 'Text_int)
-   (Parameter.set 'Token_Method 'Token_English)
-   (Parameter.set 'POS_Method Classic_POS)
-   (Parameter.set 'Phrasify_Method Classic_Phrasify)
-   (Parameter.set 'Word_Method Classic_Word)
-   (Parameter.set 'Pause_Method Classic_Pauses)
-   (Parameter.set 'PostLex_Method Classic_PostLex)
+   (Param.set 'Token_Method 'Token_English)
+   (Param.set 'POS_Method Classic_POS)
+   (Param.set 'Phrasify_Method Classic_Phrasify)
+   (Param.set 'Word_Method Classic_Word)
+   (Param.set 'Pause_Method Classic_Pauses)
+   (Param.set 'PostLex_Method Classic_PostLex)
    ;; From pos.scm:
    (set! pos_p_start_tag "punc")
    (set! pos_pp_start_tag "nn")

--- a/lib/voices.scm
+++ b/lib/voices.scm
@@ -237,6 +237,35 @@ These names can be used as arguments to voice.description and
 voice.describe."
    (mapcar car voice-locations))
 
+(define (voice.find parameters)
+"(voice.find PARAMETERS)
+List of the (potential) voices in the system that match the PARAMETERS described
+in the proclaim_voice description fields."
+  (let ((voices (eval (list voice.list)))
+        (validvoices nil)
+        (voice nil)
+       )
+    (while parameters
+      (while voices
+        (set! voice (car voices))
+;;I believe the next line should be improved. equal? doesn't work always.
+        (if (equal? (list (cadr (assoc (caar parameters)
+                                       (cadr (assoc voice Voice_descriptions))
+                                ))) (cdar parameters))
+            (begin
+              (set! validvoices (append (list voice) validvoices))
+            )
+        )
+        (set! voices (cdr voices))
+      )
+      (set! voices validvoices)
+      (set! validvoices nil)
+      (set! parameters (cdr parameters))
+    )
+  voices
+  )
+)
+
 ;; Voices are found on the voice-path if they are in directories of the form
 ;;		DIR/LANGUAGE/NAME
 

--- a/lib/voices.scm
+++ b/lib/voices.scm
@@ -437,16 +437,38 @@ the default voice. [see Site initialization]")
   "default-voice-priority-list
    List of voice names. The first of them available becomes the default voice.")
 
-(let ((voices default-voice-priority-list)
-      voice)
-  (while (and voices (eq voice_default 'no_voice_error))
-	 (set! voice (car voices))
-	 (if (assoc voice voice-locations)
-	     (set! voice_default (intern (string-append "voice_" voice)))
-	     )
-	 (set! voices (cdr voices))
-	 )
+
+(define (voice.remove_unavailable voices)
+ "voice.remove_unavailable VOICES takes a list of voice names and returns
+a list with the voices in VOICES available."
+  (let ((output (mapcar (lambda(x) (if (assoc (intern x) voice-locations ) (intern x))) voices)))
+    (while (member nil output)
+       (set! output (remove nil output))
+    )
+  output
   )
+)
 
 
+
+(define (set_voice_default voices)
+ "set_voice_default VOICES sets as voice_default the first voice available from VOICES list"
+  (let ( (avail_voices (voice.remove_unavailable voices))
+       )
+       (if avail_voices
+         (begin
+           (set! voice_default (intern (string-append "voice_" (car avail_voices))))
+          t
+         )
+         (begin 
+           (print "Could not find any of these voices:")
+           (print voices)
+           nil
+         )
+       )
+  )
+)
+
+
+(set_voice_default default-voice-priority-list)
 (provide 'voices)


### PR DESCRIPTION
This is also a rather big contribution. Most of it comes from my old (2010) contributions to the festival Debian package.

On the **language selection** perspective, instead of a hardcoded list of options in `language.list`, we use a system similar to the one used in voices (proclaim_language) which allows third party language modules to define themselves by placing a file in the libdir/languages/ directory.

On the **voice selection** perspective, a `voice.find` function is provided that enables us to find installed voices that fulfill a criteria (such as the gender, language or engine that they use if they specify it).

The default voice list is extended to include on the lowest priority any installed voices. The aim is that even if the user did not install any of the hardcoded default voice, a voice is always selected.

Last but not least, a few global synthesis options were missing in the `voice_reset` function. I added them.

If you think this is too much, feel free to tell me. In Debian it has been useful...